### PR TITLE
increase default map zoom on load

### DIFF
--- a/lib/ui/map/street_review_map_screen.dart
+++ b/lib/ui/map/street_review_map_screen.dart
@@ -245,7 +245,7 @@ class _FullMapState extends State<FullMap> {
     // not performant on a iphone 6s below z15
     // suggests importance of switching to geojson overlay
     if (_mapController.isCameraMoving == false &&
-        _mapController.cameraPosition.zoom > 12) {
+        _mapController.cameraPosition.zoom >= 12) {
       setState(() {
         _zoomInToTap = false;
       });

--- a/lib/ui/map/street_select_map_screen.dart
+++ b/lib/ui/map/street_select_map_screen.dart
@@ -332,14 +332,11 @@ class _FullMapState extends State<FullMap> {
     // not performant on a iphone 6s below z15
     // suggests importance of switching to geojson overlay
     if (_mapController.isCameraMoving == false &&
-        _mapController.cameraPosition.zoom < 15.5) {
-      setState(() {
-        _zoomInToTap = true;
-      });
-    } else {
+        _mapController.cameraPosition.zoom > 15.5) {
       setState(() {
         _zoomInToTap = false;
       });
+
       LatLngBounds bounds = await _mapController.getVisibleRegion();
 
       // TOOD need to filter filter for box contains?

--- a/lib/ui/map/street_select_map_screen.dart
+++ b/lib/ui/map/street_select_map_screen.dart
@@ -332,7 +332,11 @@ class _FullMapState extends State<FullMap> {
     // not performant on a iphone 6s below z15
     // suggests importance of switching to geojson overlay
     if (_mapController.isCameraMoving == false &&
-        _mapController.cameraPosition.zoom > 15.5) {
+        _mapController.cameraPosition.zoom < 15.5) {
+      setState(() {
+        _zoomInToTap = true;
+      });
+    } else {
       setState(() {
         _zoomInToTap = false;
       });
@@ -415,7 +419,7 @@ class _FullMapState extends State<FullMap> {
       LocationData locationData = await location.getLocation();
       LatLng newLatLng =
           new LatLng(locationData.latitude, locationData.longitude);
-      CameraUpdate cameraUpdate = CameraUpdate.newLatLngZoom(newLatLng, 12);
+      CameraUpdate cameraUpdate = CameraUpdate.newLatLngZoom(newLatLng, 16);
       _mapController.moveCamera(cameraUpdate);
       _mapController.addListener(_onMapChanged);
       _mapController.onLineTapped.add(_onLineTapped);
@@ -569,9 +573,9 @@ class _IconTextButtonState extends State<IconTextButton> {
           this.widget.callback();
         },
         style: TextButton.styleFrom(
-            primary: Colors.black,
-            padding: EdgeInsets.all(10.0),
-          ),
+          primary: Colors.black,
+          padding: EdgeInsets.all(10.0),
+        ),
         child: Row(children: [Icon(widget.icon), Text(this.widget.label)]));
   }
 }


### PR DESCRIPTION
increases the default map scale on load as partial fix for #60 

this is incomplete however, because the flutter_mapbox component doesn't return the current map zoom/window until the map is moved by the user. need to fix that so the flutter map component is aware that the map is zoomed correctly on initial map draw.