### PR TITLE
bumped ble android permissions request for fine_location

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,5 +48,6 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />  
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />  
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/> 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 </manifest>


### PR DESCRIPTION
First crack at fixing #114 added to manifest file (per https://developer.android.com/guide/topics/connectivity/bluetooth-le):

<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /> 
<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>